### PR TITLE
implement mouse speed option

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -95,7 +95,7 @@ bool midi_enable = false;
 bool fast_forward = false;
 
 unsigned deadzone;
-unsigned sensitivity = 8;
+float mouse_speed_factor = 1.0;
 
 Bit32u MIXER_RETRO_GetFrequency();
 void MIXER_CallBack(void * userdata, uint8_t *stream, int len);
@@ -604,6 +604,7 @@ struct retro_variable vars[] = {
     { "dosbox_svn_joystick_timed",          "Joystick timed intervals; true|false" },
     { "dosbox_svn_emulated_mouse",          "Gamepad emulated mouse; enable|disable" },
     { "dosbox_svn_emulated_mouse_deadzone", "Gamepad emulated deadzone; 5%|10%|15%|20%|25%|30%|0%" },
+    { "dosbox_svn_mouse_speed_factor",      "Mouse speed; 1.00|1.25|1.50|1.75|2.00|2.25|2.50|2.75|3.00|0.25|0.50|0.75" },
     { "dosbox_svn_sblaster_type",           "Sound Blaster type; sb16|sb1|sb2|sbpro1|sbpro2|gb|none" },
 #if defined(C_IPX)
     { "dosbox_svn_ipx",                     "Enable IPX over UDP; false|true" },
@@ -634,6 +635,7 @@ struct retro_variable vars_advanced[] = {
     { "dosbox_svn_joystick_timed",          "Joystick timed intervals; true|false" },
     { "dosbox_svn_emulated_mouse",          "Gamepad emulated mouse; enable|disable" },
     { "dosbox_svn_emulated_mouse_deadzone", "Gamepad emulated deadzone; 5%|10%|15%|20%|25%|30%|0%" },
+    { "dosbox_svn_mouse_speed_factor",      "Mouse speed; 1.00|1.25|1.50|1.75|2.00|2.25|2.50|2.75|3.00|0.25|0.50|0.75" },
     { "dosbox_svn_sblaster_type",           "Sound Blaster type; sb16|sb1|sb2|sbpro1|sbpro2|gb|none" },
     { "dosbox_svn_sblaster_base",           "Sound Blaster base address; 220|240|260|280|2a0|2c0|2e0|300" },
     { "dosbox_svn_sblaster_irq",            "Sound Blaster IRQ; 5|7|9|10|11|12|3" },
@@ -805,6 +807,11 @@ void check_variables()
         if (prev != deadzone)
             MAPPER_Init();
     }
+
+    var.key = "dosbox_svn_mouse_speed_factor";
+    var.value = NULL;
+    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+        mouse_speed_factor = atof(var.value);
 
     var.key = "dosbox_svn_cpu_cycles_mode";
     var.value = NULL;

--- a/libretro/libretro_mapper.cpp
+++ b/libretro/libretro_mapper.cpp
@@ -27,7 +27,7 @@ extern bool gamepad[16];
 extern bool emulated_mouse;
 
 extern unsigned deadzone;
-extern unsigned sensitivity;
+extern float mouse_speed_factor;
 
 static bool keyboardState[KBD_LAST];
 static bool slowMouse;
@@ -580,28 +580,33 @@ void MAPPER_Run(bool pressed)
         int16_t emulated_mouseX = input_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X);
         int16_t emulated_mouseY = input_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y);
 
-       if (abs(emulated_mouseX) <= deadzone * 32768 / 100)
+        if (abs(emulated_mouseX) <= deadzone * 32768 / 100)
             emulated_mouseX = 0;
-       if (abs(emulated_mouseY) <= deadzone * 32768 / 100)
+        if (abs(emulated_mouseY) <= deadzone * 32768 / 100)
             emulated_mouseY = 0;
 
-       float slowdown = 32768.0;
-       if (fastMouse)
-       {
-           slowdown /= 3.0;
-       }
-       if (slowMouse)
-       {
-           slowdown *= 8.0;
-       }
+        float slowdown = 32768.0;
+        if (fastMouse)
+            slowdown /= 3.0;
+        if (slowMouse)
+            slowdown *= 8.0;
 
-       float adjusted_emulated_mouseX = (float) emulated_mouseX * (float) sensitivity / slowdown;
-       float adjusted_emulated_mouseY = (float) emulated_mouseY * (float) sensitivity / slowdown;
+        float adjusted_emulated_mouseX = (float) emulated_mouseX * mouse_speed_factor * 8.0 / slowdown;
+        float adjusted_emulated_mouseY = (float) emulated_mouseY * mouse_speed_factor * 8.0 / slowdown;
 
        Mouse_CursorMoved(adjusted_emulated_mouseX, adjusted_emulated_mouseY, 0, 0, true);
     }
     if(mouseX || mouseY)
-        Mouse_CursorMoved(mouseX, mouseY, 0, 0, true);
+    {
+        float slowdown = 1.0;
+        if (fastMouse)
+            slowdown /= 3.0;
+        if (slowMouse)
+            slowdown *= 8.0;
+        float adjusted_mouseX = (float) mouseX * mouse_speed_factor / slowdown;
+        float adjusted_mouseY = (float) mouseY * mouse_speed_factor / slowdown;
+        Mouse_CursorMoved(adjusted_mouseX, adjusted_mouseY, 0, 0, true);
+    }
     for (std::vector<Processable*>::iterator i = inputList.begin(); i != inputList.end(); i ++)
         (*i)->process();
 }


### PR DESCRIPTION
This PR implements a core option to adjust emulated mouse speed, called simply `Mouse speed`. The default `1.00` is the same speed as it always was. With the option, it can be changed between `0.25` and `3.00` in steps of `0.25`.

The `Mouse speed` setting affects all mouse input, e.g. gamepad emulated mouse and physical mouse are all affected.

This is useful because some MS-Dos games have really fast mouse motion, some are really slow. There's usually no mouse speed option in the games themselves. Therefore, adjusting the mouse speed via a core option is sometimes helpful to make it easier to play some games.

Tested and ready to merge, @twinaphex !
