### PR TITLE
increase maximum mouse speed setting to 5.0 (was 3.0)

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -604,7 +604,7 @@ struct retro_variable vars[] = {
     { "dosbox_svn_joystick_timed",          "Joystick timed intervals; true|false" },
     { "dosbox_svn_emulated_mouse",          "Gamepad emulated mouse; enable|disable" },
     { "dosbox_svn_emulated_mouse_deadzone", "Gamepad emulated deadzone; 5%|10%|15%|20%|25%|30%|0%" },
-    { "dosbox_svn_mouse_speed_factor",      "Mouse speed; 1.00|1.25|1.50|1.75|2.00|2.25|2.50|2.75|3.00|0.25|0.50|0.75" },
+    { "dosbox_svn_mouse_speed_factor",      "Mouse speed; 1.00|1.25|1.50|1.75|2.00|2.25|2.50|2.75|3.00|3.25|3.50|3.75|4.00|4.25|4.50|4.75|5.00|0.25|0.50|0.75" },
     { "dosbox_svn_sblaster_type",           "Sound Blaster type; sb16|sb1|sb2|sbpro1|sbpro2|gb|none" },
 #if defined(C_IPX)
     { "dosbox_svn_ipx",                     "Enable IPX over UDP; false|true" },
@@ -635,7 +635,7 @@ struct retro_variable vars_advanced[] = {
     { "dosbox_svn_joystick_timed",          "Joystick timed intervals; true|false" },
     { "dosbox_svn_emulated_mouse",          "Gamepad emulated mouse; enable|disable" },
     { "dosbox_svn_emulated_mouse_deadzone", "Gamepad emulated deadzone; 5%|10%|15%|20%|25%|30%|0%" },
-    { "dosbox_svn_mouse_speed_factor",      "Mouse speed; 1.00|1.25|1.50|1.75|2.00|2.25|2.50|2.75|3.00|0.25|0.50|0.75" },
+    { "dosbox_svn_mouse_speed_factor",      "Mouse speed; 1.00|1.25|1.50|1.75|2.00|2.25|2.50|2.75|3.00|3.25|3.50|3.75|4.00|4.25|4.50|4.75|5.00|0.25|0.50|0.75" },
     { "dosbox_svn_sblaster_type",           "Sound Blaster type; sb16|sb1|sb2|sbpro1|sbpro2|gb|none" },
     { "dosbox_svn_sblaster_base",           "Sound Blaster base address; 220|240|260|280|2a0|2c0|2e0|300" },
     { "dosbox_svn_sblaster_irq",            "Sound Blaster IRQ; 5|7|9|10|11|12|3" },


### PR DESCRIPTION
useful for games like Rise of the Triad, where the mouse is very
slow.