### PR TITLE
Use separate options for horizontal and vertical mouse speed

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -95,7 +95,8 @@ bool midi_enable = false;
 bool fast_forward = false;
 
 unsigned deadzone;
-float mouse_speed_factor = 1.0;
+float mouse_speed_factor_x = 1.0;
+float mouse_speed_factor_y = 1.0;
 
 Bit32u MIXER_RETRO_GetFrequency();
 void MIXER_CallBack(void * userdata, uint8_t *stream, int len);
@@ -585,6 +586,8 @@ static struct retro_disk_control_callback disk_interface = {
     disk_add_image_index,
 };
 
+#define MOUSE_SPEED_FACTORS "1.00|1.25|1.50|1.75|2.00|2.25|2.50|2.75|3.00|3.25|3.50|3.75|4.00|4.25|4.50|4.75|5.00|0.25|0.50|0.75"
+
 struct retro_variable vars[] = {
     { "dosbox_svn_use_options",             "Enable core-options (restart); true|false"},
     { "dosbox_svn_adv_options",             "Enable advanced core-options (restart); false|true"},
@@ -604,7 +607,8 @@ struct retro_variable vars[] = {
     { "dosbox_svn_joystick_timed",          "Joystick timed intervals; true|false" },
     { "dosbox_svn_emulated_mouse",          "Gamepad emulated mouse; enable|disable" },
     { "dosbox_svn_emulated_mouse_deadzone", "Gamepad emulated deadzone; 5%|10%|15%|20%|25%|30%|0%" },
-    { "dosbox_svn_mouse_speed_factor",      "Mouse speed; 1.00|1.25|1.50|1.75|2.00|2.25|2.50|2.75|3.00|3.25|3.50|3.75|4.00|4.25|4.50|4.75|5.00|0.25|0.50|0.75" },
+    { "dosbox_svn_mouse_speed_factor_x",    "Horizontal mouse speed; " MOUSE_SPEED_FACTORS },
+    { "dosbox_svn_mouse_speed_factor_y",    "Vertical mouse speed; " MOUSE_SPEED_FACTORS },
     { "dosbox_svn_sblaster_type",           "Sound Blaster type; sb16|sb1|sb2|sbpro1|sbpro2|gb|none" },
 #if defined(C_IPX)
     { "dosbox_svn_ipx",                     "Enable IPX over UDP; false|true" },
@@ -635,7 +639,8 @@ struct retro_variable vars_advanced[] = {
     { "dosbox_svn_joystick_timed",          "Joystick timed intervals; true|false" },
     { "dosbox_svn_emulated_mouse",          "Gamepad emulated mouse; enable|disable" },
     { "dosbox_svn_emulated_mouse_deadzone", "Gamepad emulated deadzone; 5%|10%|15%|20%|25%|30%|0%" },
-    { "dosbox_svn_mouse_speed_factor",      "Mouse speed; 1.00|1.25|1.50|1.75|2.00|2.25|2.50|2.75|3.00|3.25|3.50|3.75|4.00|4.25|4.50|4.75|5.00|0.25|0.50|0.75" },
+    { "dosbox_svn_mouse_speed_factor_x",    "Horizontal mouse speed; " MOUSE_SPEED_FACTORS },
+    { "dosbox_svn_mouse_speed_factor_y",    "Vertical mouse speed; " MOUSE_SPEED_FACTORS },
     { "dosbox_svn_sblaster_type",           "Sound Blaster type; sb16|sb1|sb2|sbpro1|sbpro2|gb|none" },
     { "dosbox_svn_sblaster_base",           "Sound Blaster base address; 220|240|260|280|2a0|2c0|2e0|300" },
     { "dosbox_svn_sblaster_irq",            "Sound Blaster IRQ; 5|7|9|10|11|12|3" },
@@ -808,10 +813,15 @@ void check_variables()
             MAPPER_Init();
     }
 
-    var.key = "dosbox_svn_mouse_speed_factor";
+    var.key = "dosbox_svn_mouse_speed_factor_x";
     var.value = NULL;
     if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-        mouse_speed_factor = atof(var.value);
+        mouse_speed_factor_x = atof(var.value);
+
+    var.key = "dosbox_svn_mouse_speed_factor_y";
+    var.value = NULL;
+    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+        mouse_speed_factor_y = atof(var.value);
 
     var.key = "dosbox_svn_cpu_cycles_mode";
     var.value = NULL;

--- a/libretro/libretro_mapper.cpp
+++ b/libretro/libretro_mapper.cpp
@@ -27,7 +27,8 @@ extern bool gamepad[16];
 extern bool emulated_mouse;
 
 extern unsigned deadzone;
-extern float mouse_speed_factor;
+extern float mouse_speed_factor_x;
+extern float mouse_speed_factor_y;
 
 static bool keyboardState[KBD_LAST];
 static bool slowMouse;
@@ -591,8 +592,8 @@ void MAPPER_Run(bool pressed)
         if (slowMouse)
             slowdown *= 8.0;
 
-        float adjusted_emulated_mouseX = (float) emulated_mouseX * mouse_speed_factor * 8.0 / slowdown;
-        float adjusted_emulated_mouseY = (float) emulated_mouseY * mouse_speed_factor * 8.0 / slowdown;
+        float adjusted_emulated_mouseX = (float) emulated_mouseX * mouse_speed_factor_x * 8.0 / slowdown;
+        float adjusted_emulated_mouseY = (float) emulated_mouseY * mouse_speed_factor_y * 8.0 / slowdown;
 
        Mouse_CursorMoved(adjusted_emulated_mouseX, adjusted_emulated_mouseY, 0, 0, true);
     }
@@ -603,8 +604,8 @@ void MAPPER_Run(bool pressed)
             slowdown /= 3.0;
         if (slowMouse)
             slowdown *= 8.0;
-        float adjusted_mouseX = (float) mouseX * mouse_speed_factor / slowdown;
-        float adjusted_mouseY = (float) mouseY * mouse_speed_factor / slowdown;
+        float adjusted_mouseX = (float) mouseX * mouse_speed_factor_x / slowdown;
+        float adjusted_mouseY = (float) mouseY * mouse_speed_factor_y / slowdown;
         Mouse_CursorMoved(adjusted_mouseX, adjusted_mouseY, 0, 0, true);
     }
     for (std::vector<Processable*>::iterator i = inputList.begin(); i != inputList.end(); i ++)


### PR DESCRIPTION
Some games need separate X/Y mouse sensitivity. Especially SVGA point&click adventures are difficult to play otherwise. All Legend Entertainment games (like Eric the Unready, Gateway, Death Gate, Shannara, etc.) have an X/Y mouse speed ratio of about 2:1.

This patch just splits the current mouse speed option into two, one for horizontal and one for vertical speed.