### PR TITLE
Restore vanilla mixer code and use guards for libretro changes

### DIFF
--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -17,7 +17,14 @@
  */
 
 
+/*
+	Remove the sdl code from here and have it handeld in the sdlmain.
+	That should call the mixer start from there or something.
+*/
+
+#ifdef __LIBRETRO__
 #include <stdlib.h>
+#endif
 #include <string.h>
 #include <sys/types.h>
 #include <math.h>
@@ -31,6 +38,11 @@
 #include <mmsystem.h>
 #endif
 
+#ifdef WITH_FAKE_SDL
+#include "SDL/SDL.h"
+#else
+#include <SDL/SDL.h>
+#endif
 #include "mem.h"
 #include "pic.h"
 #include "dosbox.h"
@@ -58,6 +70,12 @@
 #define TICK_SHIFT 14
 #define TICK_NEXT ( 1 << TICK_SHIFT)
 #define TICK_MASK (TICK_NEXT -1)
+
+#ifdef __LIBRETRO__
+#define SDL_LockAudio()
+#define SDL_UnlockAudio()
+#define SDL_PauseAudio(a)
+#endif
 
 
 static INLINE Bit16s MIXER_CLIP(Bits SAMP) {
@@ -87,8 +105,12 @@ Bit8u MixTemp[MIXER_BUFSIZE];
 
 MixerChannel * MIXER_AddChannel(MIXER_Handler handler,Bitu freq,const char * name) {
 	MixerChannel * chan=new MixerChannel();
+
+#ifdef __LIBRETRO__
 	if (!chan)
 		return NULL;
+#endif
+
 	chan->scale = 1.0;
 	chan->handler=handler;
 	chan->name=name;
@@ -145,7 +167,9 @@ void MixerChannel::Enable(bool _yesno) {
 	enabled=_yesno;
 	if (enabled) {
 		freq_counter = 0;
+		SDL_LockAudio();
 		if (done<mixer.done) done=mixer.done;
+		SDL_UnlockAudio();
 	}
 }
 
@@ -377,16 +401,25 @@ void MixerChannel::AddSamples_s32_nonnative(Bitu len,const Bit32s * data) {
 }
 
 void MixerChannel::FillUp(void) {
+	SDL_LockAudio();
 	if (!enabled || done<mixer.done) {
+		SDL_UnlockAudio();
 		return;
 	}
 	float index=PIC_TickIndex();
 	Mix((Bitu)(index*mixer.needed));
+	SDL_UnlockAudio();
 }
 
 extern bool ticksLocked;
 static inline bool Mixer_irq_important(void) {
+#ifndef __LIBRETRO__
+	/* In some states correct timing of the irqs is more important then
+	 * non stuttering audo */
+	return (ticksLocked || (CaptureState & (CAPTURE_WAVE|CAPTURE_VIDEO)));
+#else
 	return (ticksLocked);
+#endif
 }
 
 static Bit32u calc_tickadd(Bit32u freq) {
@@ -407,6 +440,23 @@ static void MIXER_MixData(Bitu needed) {
 		chan->Mix(needed);
 		chan=chan->next;
 	}
+#ifndef __LIBRETRO__
+	if (CaptureState & (CAPTURE_WAVE|CAPTURE_VIDEO)) {
+		Bit16s convert[1024][2];
+		Bitu added=needed-mixer.done;
+		if (added>1024)
+			added=1024;
+		Bitu readpos=(mixer.pos+mixer.done)&MIXER_BUFMASK;
+		for (Bitu i=0;i<added;i++) {
+			Bits sample=mixer.work[readpos][0] >> MIXER_VOLSHIFT;
+			convert[i][0]=MIXER_CLIP(sample);
+			sample=mixer.work[readpos][1] >> MIXER_VOLSHIFT;
+			convert[i][1]=MIXER_CLIP(sample);
+			readpos=(readpos+1)&MIXER_BUFMASK;
+		}
+		CAPTURE_AddWave( mixer.freq, added, (Bit16s*)convert );
+	}
+#endif
 	//Reset the the tick_add for constant speed
 	if( Mixer_irq_important() )
 		mixer.tick_add = calc_tickadd(mixer.freq);
@@ -414,10 +464,12 @@ static void MIXER_MixData(Bitu needed) {
 }
 
 static void MIXER_Mix(void) {
+	SDL_LockAudio();
 	MIXER_MixData(mixer.needed);
 	mixer.tick_counter += mixer.tick_add;
 	mixer.needed+=(mixer.tick_counter >> TICK_SHIFT);
 	mixer.tick_counter &= TICK_MASK;
+	SDL_UnlockAudio();
 }
 
 static void MIXER_Mix_NoSound(void) {
@@ -440,7 +492,12 @@ static void MIXER_Mix_NoSound(void) {
 	mixer.done=0;
 }
 
-void MIXER_CallBack(void * userdata, Uint8 *stream, int len) {
+#ifndef __LIBRETRO__
+static void SDLCALL
+#else
+void
+#endif
+MIXER_CallBack(void * userdata, Uint8 *stream, int len) {
 	Bitu need=(Bitu)len/MIXER_SSIZE;
 	Bit16s * output=(Bit16s *)stream;
 	Bitu reduce;
@@ -653,14 +710,41 @@ void MIXER_Init(Section* sec) {
 	mixer.mastervol[0]=1.0f;
 	mixer.mastervol[1]=1.0f;
 
+#ifndef __LIBRETRO__
+	/* Start the Mixer using SDL Sound at 22 khz */
+	SDL_AudioSpec spec;
+	SDL_AudioSpec obtained;
+
+	spec.freq=mixer.freq;
+	spec.format=AUDIO_S16SYS;
+	spec.channels=2;
+	spec.callback=MIXER_CallBack;
+	spec.userdata=NULL;
+	spec.samples=(Uint16)mixer.blocksize;
+#endif
+
 	mixer.tick_counter=0;
-	if (mixer.nosound || mixer.freq > 49716) {
+	if (mixer.nosound) {
 		LOG_MSG("MIXER: No Sound Mode Selected.");
 		mixer.tick_add=calc_tickadd(mixer.freq);
 		TIMER_AddTickHandler(MIXER_Mix_NoSound);
+#ifndef __LIBRETRO__
+	} else if (SDL_OpenAudio(&spec, &obtained) <0 ) {
+		mixer.nosound = true;
+		LOG_MSG("MIXER: Can't open audio: %s , running in nosound mode.",SDL_GetError());
+		mixer.tick_add=calc_tickadd(mixer.freq);
+		TIMER_AddTickHandler(MIXER_Mix_NoSound);
+#endif
 	} else {
+#ifndef __LIBRETRO__
+		if((mixer.freq != obtained.freq) || (mixer.blocksize != obtained.samples))
+			LOG_MSG("MIXER: Got different values from SDL: freq %d, blocksize %d",obtained.freq,obtained.samples);
+		mixer.freq=obtained.freq;
+		mixer.blocksize=obtained.samples;
+#endif
 		mixer.tick_add=calc_tickadd(mixer.freq);
 		TIMER_AddTickHandler(MIXER_Mix);
+		SDL_PauseAudio(0);
 	}
 	mixer.min_needed=section->Get_int("prebuffer");
 	if (mixer.min_needed>100) mixer.min_needed=100;
@@ -670,8 +754,10 @@ void MIXER_Init(Section* sec) {
 	PROGRAMS_MakeFile("MIXER.COM",MIXER_ProgramStart);
 }
 
+#ifdef __LIBRETRO__
 // Need to put it in the av_info struct
 Bit32u MIXER_RETRO_GetFrequency()
 {
 	return mixer.freq;
 }
+#endif


### PR DESCRIPTION
In my previous PR (#14) , I did a rebase of the old mixer fork to current SVN, unconditionally removing vanilla code and adding libretro-specific one. Turns out this was a no-no.

This PR restores the vanilla dosbox code and guards modifications depending on whether or not `__LIBRETRO__` is set.