### PR TITLE
Shut down dosbox when E_Exit is called

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -136,7 +136,7 @@ extern struct retro_midi_interface *retro_midi_interface;
 static std::string loadPath;
 static std::string gamePath;
 static std::string configPath;
-static bool dosbox_exit;
+bool dosbox_exit;
 static bool frontend_exit;
 static bool is_restarting = false;
 

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -34,6 +34,7 @@
 #include "video.h"
 
 #ifdef __LIBRETRO__
+#include <libco.h>
 #include "libretro.h"
 extern retro_log_printf_t log_cb;
 #endif
@@ -191,9 +192,13 @@ void E_Exit(const char * format,...) {
 	strcat(buf,"\n");
 
 #ifdef __LIBRETRO__
+	extern bool dosbox_exit;
+	extern cothread_t mainThread;
+
 	if(log_cb)
 		log_cb(RETRO_LOG_ERROR, buf);
-#else
-	throw(buf);
+	dosbox_exit = true;
+	co_switch(mainThread);
 #endif
+	throw(buf);
 }


### PR DESCRIPTION
There's lots of places where E_Exit is called in vanilla. This is supposed to exit dosbox and the function is not supposed to return. The libretro core however does not do that.

Currently, a call to E_Exit() results in a call to abort() because the function is marked noreturn but it returns. Removing the noreturn attribute attribute is not a good solution, because dosbox will then keep running but in an undefined state.

We fix this by exiting the emulation thread and then shutting down dosbox.