### PR TITLE
Add separate X/Y mouse speed settings to v2 options

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -588,8 +588,6 @@ static struct retro_disk_control_callback disk_interface = {
     disk_add_image_index,
 };
 
-#define MOUSE_SPEED_FACTORS "1.00|1.25|1.50|1.75|2.00|2.25|2.50|2.75|3.00|3.25|3.50|3.75|4.00|4.25|4.50|4.75|5.00|0.25|0.50|0.75"
-
 void check_variables()
 {
     struct retro_variable var = {0};

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -48,6 +48,31 @@ extern "C" {
  * - Will be used as a fallback for any missing entries in
  *   frontend language definition */
 
+#define MOUSE_SPEED_FACTORS \
+    { \
+        { "0.25", NULL }, \
+        { "0.50", NULL }, \
+        { "0.75", NULL }, \
+        { "1.00", NULL }, \
+        { "1.25", NULL }, \
+        { "1.50", NULL }, \
+        { "1.75", NULL }, \
+        { "2.00", NULL }, \
+        { "2.25", NULL }, \
+        { "2.50", NULL }, \
+        { "2.75", NULL }, \
+        { "3.00", NULL }, \
+        { "3.25", NULL }, \
+        { "3.50", NULL }, \
+        { "3.75", NULL }, \
+        { "4.00", NULL }, \
+        { "4.25", NULL }, \
+        { "4.50", NULL }, \
+        { "4.75", NULL }, \
+        { "5.00", NULL }, \
+        { NULL, NULL } \
+    }
+
 struct retro_core_option_definition option_defs_us[] = {
    {
       "dosbox_svn_use_options",
@@ -319,29 +344,17 @@ struct retro_core_option_definition option_defs_us[] = {
       "30%"
    },
    {
-      "dosbox_svn_mouse_speed_factor",
-      "Input: Gamepad emulated mouse speed",
-      "Speed of the gamepad emulated mouse. Experiment with this value if the cursor moves too fast or too slow with your gamepad.",
-      {
-         { "1.00", NULL },
-         { "1.25", NULL },
-         { "1.50", NULL },
-         { "1.75", NULL },
-         { "2.00", NULL },
-         { "2.25", NULL },
-         { "2.50", NULL },
-         { "2.75", NULL },
-         { "3.00", NULL },
-         { "3.25", NULL },
-         { "3.50", NULL },
-         { "3.75", NULL },
-         { "4.00", NULL },
-         { "4.25", NULL },
-         { "4.50", NULL },
-         { "4.75", NULL },
-         { "5.00", NULL },
-         { NULL, NULL },
-      },
+      "dosbox_svn_mouse_speed_factor_x",
+      "Input: Horizontal mouse sensitivity.",
+      "Experiment with this value if the mouse is too fast when moving left/right.",
+      MOUSE_SPEED_FACTORS,
+      "1.00"
+   },
+   {
+      "dosbox_svn_mouse_speed_factor_y",
+      "Input: Vertical mouse sensitivity.",
+      "Experiment with this value if the mouse is too fast when moving up/down.",
+      MOUSE_SPEED_FACTORS,
       "1.00"
    },
    {


### PR DESCRIPTION
These got lost when core options were updated to v2. Re-add them.