### PR TITLE
Add option for synchronizing dosbox to the front-end

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -108,6 +108,28 @@ struct retro_core_option_definition option_defs_us[] = {
       "false"
    },
    {
+      "dosbox_svn_core_timing",
+      "Core: Timing method",
+      "The independent modes allow DOSBox to ignore the frontend's frame timing. DOSBox will "
+      "render frames at its own pace rather than at the request of the frontend. This adds about 1 "
+      "frame of input lag, can introduce stutter/judder, but allows the \"auto\" and \"max\" "
+      "cycles settings to work correctly.\n"
+      "\n"
+      "Syncing to the frontend offers about 1 frame of lower input lag. However, this prevents the "
+      "\"auto\" and \"max\" cycles settings from working correctly and you need to use a fixed "
+      "cycle count instead. In this mode, the framerate is chosen by the frontend; if the emulated "
+      "DOSBox video card refresh rate is near the refresh rate of your display, it will reclock "
+      "the core to match your display in order to eliminate stutter. Otherwise, the core will run "
+      "at the emulated framerate.",
+      {
+         { "unsynced", "Independent, run frontend at 60FPS" },
+         { "match_fps", "Independent, run frontend at emulated refresh rate" },
+         { "synced", "Synchronize to frontend" },
+         { NULL, NULL },
+      },
+      "unsynced"
+   },
+   {
       "dosbox_svn_machine_type",
       "System: Emulated machine",
       "The type of machine that DOSBox will try to emulate (restart).",
@@ -350,17 +372,6 @@ struct retro_core_option_definition option_defs_us[] = {
          { NULL, NULL },
       },
       "none"
-   },
-   {
-      "dosbox_svn_use_native_refresh",
-      "Video: Enable refresh rate switching",
-      "Enable refresh rate switching to match running content. This is a expensive operation and may cause the screen to flicker.",
-      {
-         { "false", NULL },
-         { "true", NULL },
-         { NULL, NULL },
-      },
-      "false"
    },
    {
       "dosbox_svn_joystick_timed",

--- a/libretro/libretro_dosbox.h
+++ b/libretro/libretro_dosbox.h
@@ -1,17 +1,27 @@
 #ifndef _LIBRETRO_DOSBOX_H
 #define _LIBRETRO_DOSBOX_H
 
+#include <libco.h>
 #include <string>
 #include <stdint.h>
 #include "libretro.h"
 
 # define RETROLOG(msg) printf("%s\n", msg)
 
+enum CoreTimingMethod {
+    CORE_TIMING_UNSYNCED,
+    CORE_TIMING_MATCH_FPS,
+    CORE_TIMING_SYNCED
+};
+
 extern retro_video_refresh_t video_cb;
 extern retro_audio_sample_batch_t audio_batch_cb;
 extern retro_input_poll_t poll_cb;
 extern retro_input_state_t input_cb;
 extern retro_environment_t environ_cb;
+extern cothread_t emuThread;
+extern cothread_t mainThread;
+extern CoreTimingMethod core_timing;
 
 bool update_dosbox_variable(std::string section_string, std::string var_string, std::string val_string);
 

--- a/libretro/libretro_gfx.cpp
+++ b/libretro/libretro_gfx.cpp
@@ -1,12 +1,14 @@
+#include <libco.h>
 #include <string.h>
-#include "libretro.h"
 #include "dosbox.h"
+#include "libretro.h"
+#include "libretro_dosbox.h"
 #include "video.h"
 
 Bit8u RDOSGFXbuffer[1024*768*4];
+Bit8u RDOSGFXhaveFrame[sizeof(RDOSGFXbuffer)];
 Bitu RDOSGFXwidth, RDOSGFXheight, RDOSGFXpitch;
 unsigned RDOSGFXcolorMode = RETRO_PIXEL_FORMAT_0RGB1555;
-Bit8u RDOSGFXhaveFrame[sizeof(RDOSGFXbuffer)];
 
 Bitu GFX_GetBestMode(Bitu flags)
 {
@@ -42,7 +44,10 @@ bool GFX_StartUpdate(Bit8u * & pixels,Bitu & pitch)
 
 void GFX_EndUpdate( const Bit16u *changedLines )
 {
-    memcpy(RDOSGFXhaveFrame, RDOSGFXbuffer, sizeof(RDOSGFXbuffer));
+    if (core_timing == CORE_TIMING_SYNCED)
+        video_cb(changedLines ? RDOSGFXbuffer : NULL, RDOSGFXwidth, RDOSGFXheight, RDOSGFXpitch);
+    else
+        memcpy(RDOSGFXhaveFrame, RDOSGFXbuffer, sizeof(RDOSGFXbuffer));
 }
 
 // Stubs

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -165,7 +165,11 @@ static Bitu Normal_Loop(void) {
 #define wrap_delay(a) SDL_Delay(a)
 
 void increaseticks() { //Make it return ticksRemain and set it in the function above to remove the global variable.
+#ifndef __LIBRETRO__
 	if (GCC_UNLIKELY(ticksLocked)) { // For Fast Forward Mode
+#else
+	if (ticksLocked) { // For Fast Forward Mode
+#endif
 		ticksRemain=5;
 		/* Reset any auto cycle guessing for this frame */
 		ticksLast = GetTicks();

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -24,6 +24,7 @@
 
 #ifdef __LIBRETRO__
 #include <stdlib.h>
+#include "libretro_dosbox.h"
 #endif
 #include <string.h>
 #include <sys/types.h>
@@ -418,7 +419,8 @@ static inline bool Mixer_irq_important(void) {
 	 * non stuttering audo */
 	return (ticksLocked || (CaptureState & (CAPTURE_WAVE|CAPTURE_VIDEO)));
 #else
-	return (ticksLocked);
+	/* In synced mode, prefer non stuttering audio */
+	return ticksLocked && core_timing != CORE_TIMING_SYNCED;
 #endif
 }
 


### PR DESCRIPTION
The current method of timer-based scheduling to run the emulation thread (using PIC_AddEvent) results in dosbox and the front-end not running in sync. Dosbox does not render exactly one frame at the correct time so we have to always copy the last rendered frame and keep it around until the front-end requests it. As a result, there is increased input lag of up to 1 frame.

We fix this by doing a context switch to the emulator and back to the front-end exactly once every time the front-end requests a frame. We add a small change to dosbox to make it keep presenting frames even when there were no changes in the framebuffer. After presenting the frame, we switch back to the front-end. For this to work reliably, we put dosbox in fast-forward mode at startup.

As a result, there is no more delay between dosbox finishing drawing the frame and uploading it to the front-end, minimizing input lag. Also, for near-60FPS games at least, the front-end can now successfully reclock the core to match the screen refresh rate, so there shouldn't be any stutter or judder.

There is a drawback to this though: the "auto" and "max" cycles settings do not work correctly anymore. This is a side-effect of running dosbox at an unlocked speed. As a result, this mode is disabled by default and needs to be enabled in the core options.

To make it easier for users to test the three different timing modes, the "switch refresh rate" option has been removed. Now there's only one "Core: Timing method" option with three settings:

  * Independent, run frontend at 60FPS
  * Independent, run frontend at emulated refresh rate
  * Synchronize to frontend

Also, this setting can be changed at runtime and will take effect immediately without the need for a restart.

The option takes effect even if core options are disabled, since this is more of a libretro-specific setting rather than a dosbox one.

-------------

This should probably get some more testing before being merged. Works as advertised for me for all games I tested. Games respond 1 frame sooner when testing them with RA's frame advance function (`k` key), and the mouse cursor in point&click games is now 1 frame closer to the native mouse cursor rather than lagging two frames behind. I think input lag now matches stand-alone dosbox.

But I'm not 100% sure that `RENDER_Halt()` is the only place where a context switch is needed. So try as many games as you can and see if the UI locks up with any of them.