### PR TITLE
Allow 100 for coarse and 10000 for fine cycles multipliers

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -261,6 +261,7 @@ struct retro_core_option_definition option_defs_us[] = {
       "System: Coarse CPU cycles multiplier",
       "Multiplier for coarse CPU cycles tuning.",
       {
+         { "100", NULL },
          { "1000", NULL },
          { "10000", NULL },
          { "100000", NULL },
@@ -295,6 +296,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "10", NULL },
          { "100", NULL },
          { "1000", NULL },
+         { "10000", NULL },
          { NULL, NULL },
       },
       "100"


### PR DESCRIPTION
As pointed out in bug #22, it's not currently possible to configure <1000 cycles. Furthermore, it's also not possible to use something like 150'000 cycles either. By expanding the lower bound of the coarse cycles multiplier range to 100 and the maximum of the fine multiplier to 10000, it becomes possible to configure more possible cycle values.