### PR TITLE
Use a front/back buffer flip instead of memcpy in internal timing mode

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -142,8 +142,6 @@ static bool frontend_exit;
 static bool is_restarting = false;
 
 /* video variables */
-extern Bit8u RDOSGFXbuffer[1024*768*4];
-extern Bit8u RDOSGFXhaveFrame[sizeof(RDOSGFXbuffer)];
 extern Bitu RDOSGFXwidth, RDOSGFXheight, RDOSGFXpitch;
 extern unsigned RDOSGFXcolorMode;
 unsigned currentWidth, currentHeight;
@@ -1477,10 +1475,15 @@ void retro_run (void)
         co_switch(emuThread);
 
         if (core_timing == CORE_TIMING_SYNCED)
+        {
             MIXER_CallBack(0, audioData, samplesPerFrame * 4);
+        }
         else
-            /* Upload video */
-            video_cb(RDOSGFXhaveFrame, RDOSGFXwidth, RDOSGFXheight, RDOSGFXpitch);
+        {
+            video_cb(dosbox_frontbuffer_uploaded ? NULL : dosbox_frontbuffer,
+                     RDOSGFXwidth, RDOSGFXheight, RDOSGFXpitch);
+            dosbox_frontbuffer_uploaded = true;
+        }
         /* Upload audio */
         audio_batch_cb((int16_t*)audioData, samplesPerFrame);
     }

--- a/libretro/libretro_dosbox.h
+++ b/libretro/libretro_dosbox.h
@@ -4,6 +4,7 @@
 #include <libco.h>
 #include <string>
 #include <stdint.h>
+#include "config.h"
 #include "libretro.h"
 
 # define RETROLOG(msg) printf("%s\n", msg)
@@ -23,6 +24,9 @@ extern cothread_t emuThread;
 extern cothread_t mainThread;
 extern core_timing_mode core_timing;
 extern float dosbox_aspect_ratio;
+extern Bit8u dosbox_framebuffers[2][1024 * 768 * 4];
+extern Bit8u *dosbox_frontbuffer;
+extern bool dosbox_frontbuffer_uploaded;
 
 bool update_dosbox_variable(std::string section_string, std::string var_string, std::string val_string);
 

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -169,7 +169,11 @@ bool RENDER_StartUpdate(void) {
 	Scaler_ChangedLines[0] = 0;
 	Scaler_ChangedLineIndex = 0;
 	/* Clearing the cache will first process the line to make sure it's never the same */
+#ifdef __LIBRETRO__
+	if (render.scale.clearCache) {
+#else
 	if (GCC_UNLIKELY( render.scale.clearCache) ) {
+#endif
 //		LOG_MSG("Clearing cache");
 		//Will always have to update the screen with this one anyway, so let's update already
 		if (GCC_UNLIKELY(!GFX_StartUpdate( render.scale.outWrite, render.scale.outPitch )))


### PR DESCRIPTION
Hopefully this will offer acceptable performance on Wii U and other platforms that have low memory speeds.