### PR TITLE
Add Gravis Ultrasound core options

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -652,6 +652,7 @@ void check_variables()
     struct retro_core_option_display option_display;
 
     bool blaster = false;
+    bool gus = false;
 
     var.key = "dosbox_svn_use_options";
     var.value = NULL;
@@ -847,6 +848,33 @@ void check_variables()
         if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
             update_dosbox_variable("sblaster", "oplemu", var.value);
 
+        var.key = "dosbox_svn_gus";
+        var.value = NULL;
+        if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+        {
+            update_dosbox_variable("gus", "gus", var.value);
+            gus = strcmp(var.value, "true") == 0;
+        }
+
+        var.key = "dosbox_svn_gusrate";
+        var.value = NULL;
+        if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+            update_dosbox_variable("gus", "gusrate", var.value);
+
+        var.key = "dosbox_svn_gusbase";
+        var.value = NULL;
+        if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+            update_dosbox_variable("gus", "gusbase", var.value);
+
+        var.key = "dosbox_svn_gusirq";
+        var.value = NULL;
+        if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+            update_dosbox_variable("gus", "gusirq", var.value);
+
+        var.key = "dosbox_svn_gusdma";
+        var.value = NULL;
+        if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+            update_dosbox_variable("gus", "gusdma", var.value);
 
         var.key = "dosbox_svn_emulated_mouse";
         var.value = NULL;
@@ -1060,6 +1088,17 @@ void check_variables()
 	option_display.key     = "dosbox_svn_sblaster_opl_mode";
     environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 	option_display.key     = "dosbox_svn_sblaster_opl_emu";
+    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
+    /* show ultrasound options only if it's it enabled and advanced options is enabled */
+    option_display.visible = adv_core_options && gus;
+	option_display.key     = "dosbox_svn_gusrate";
+    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+	option_display.key     = "dosbox_svn_gusbase";
+    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+	option_display.key     = "dosbox_svn_gusirq";
+    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+	option_display.key     = "dosbox_svn_gusdma";
     environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 
     /* show tandy and disney options only if advanced options is enabled */

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -535,6 +535,84 @@ struct retro_core_option_definition option_defs_us[] = {
       "default"
    },
    {
+      "dosbox_svn_gus",
+      "Sound: Gravis Ultrasound support",
+      "Enables the Gravis Ultrasound emulation (restart).\n"
+      "NOTE: The ULTRADIR directory is not configurable in the core's options. It is always set to "
+      "C:\\ULTRASND, unless you use a custom .conf file and change it there.",
+      {
+         { "false", NULL },
+         { "true", NULL },
+         { NULL, NULL },
+      },
+      "false"
+   },
+   {
+      "dosbox_svn_gusrate",
+      "Sound: Ultrasound sample rate",
+      "Sample rate of Ultrasound emulation (restart).",
+      {
+         { "8000", NULL },
+         { "11025", NULL },
+         { "16000", NULL },
+         { "22050", NULL },
+         { "32000", NULL },
+         { "44100", NULL },
+         { "48000", NULL },
+         { "49716", NULL },
+         { NULL, NULL },
+      },
+      "44100"
+   },
+   {
+      "dosbox_svn_gusbase",
+      "Sound: Ultrasound IO address",
+      "The IO base address of the Gravis Ultrasound (restart).",
+      {
+         { "220", NULL },
+         { "240", NULL },
+         { "260", NULL },
+         { "280", NULL },
+         { "2a0", NULL },
+         { "2c0", NULL },
+         { "2e0", NULL },
+         { "300", NULL },
+         { NULL, NULL },
+      },
+      "240"
+   },
+   {
+      "dosbox_svn_gusirq",
+      "Sound: Ultrasound IRQ",
+      "The IRQ number of the Gravis Ultrasound (restart).",
+      {
+         { "3", NULL },
+         { "5", NULL },
+         { "7", NULL },
+         { "9", NULL },
+         { "10", NULL },
+         { "11", NULL },
+         { "12", NULL },
+         { NULL, NULL },
+      },
+      "5"
+   },
+   {
+      "dosbox_svn_gusdma",
+      "Sound: Ultrasound DMA",
+      "The DMA channel of the Gravis Ultrasound (restart).",
+      {
+         { "0", NULL },
+         { "1", NULL },
+         { "3", NULL },
+         { "5", NULL },
+         { "6", NULL },
+         { "7", NULL },
+         { NULL, NULL },
+      },
+      "3"
+   },
+   {
       "dosbox_svn_midi",
       "Sound: Enable libretro MIDI passthrough",
       "Enable libretro MIDI passthrough.",


### PR DESCRIPTION
https://github.com/libretro/dosbox-svn/issues/9.

`ULTRADIR` is not configurable. It uses the default setting (`C:\ULTRASND`) unless changed in a conf file. Fortunately, `C:\ULTRASND` is the directory the majority of people expect to have to copy the gravis drivers/patches anyway.