### PR TITLE
Fix logic error that assumed normalized path

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1442,10 +1442,8 @@ bool retro_load_game(const struct retro_game_info *game)
         {
             /* Copy the game path */
             loadPath = normalize_path(game->path);
+            gamePath = loadPath;
             const size_t lastDot = loadPath.find_last_of('.');
-            char tmp[PATH_MAX_LENGTH];
-            snprintf(tmp, sizeof(tmp), "%s", loadPath.c_str());
-            gamePath = std::string(tmp);
 
             /* Find any config file to load */
             if(std::string::npos != lastDot)

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1444,7 +1444,7 @@ bool retro_load_game(const struct retro_game_info *game)
             loadPath = normalize_path(game->path);
             const size_t lastDot = loadPath.find_last_of('.');
             char tmp[PATH_MAX_LENGTH];
-            snprintf(tmp, sizeof(tmp), "%s", game->path);
+            snprintf(tmp, sizeof(tmp), "%s", loadPath.c_str());
             gamePath = std::string(tmp);
 
             /* Find any config file to load */


### PR DESCRIPTION
It looks like `gamePath` is assumed to already be normalized with `normalize_path` [here][1]. Without this change it isn't though.

So the problem is if you pass a path like `"C:/program.exe"` to `retro_load_game` on Windows when [`dir` is extracted][1] it will equal `"C:/program.exe"` instead of `"C:/"`. This is because `std::string::find_last_of` is looking for the Windows `\` path separator and not the `/` one. This would work as intended if `gamePath` was normalized though.

[1]: https://github.com/libretro/dosbox-svn/blob/ef392e8f5839e79d435545183f07587591fc6a01/libretro/libretro.cpp#L1476