### PR TITLE
Fix embedded_sdl submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libretro/deps/embedded_sdl"]
 	path = libretro/deps/embedded_sdl
-	url = https://github.com/fr500/sdl1.2.git
+	url = https://github.com/JustEnoughLinuxOS/embedded_sdl.git
 [submodule "libretro/deps/common"]
 	path = libretro/deps/common
 	url = https://github.com/libretro/libretro-common.git


### PR DESCRIPTION
This change resolves a build issue with the libretro module as the original upstream has disappeared for embedded_sql.